### PR TITLE
Add vercel-install script and use it

### DIFF
--- a/wildmanager/vercel-install.sh
+++ b/wildmanager/vercel-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+FLUTTER_DIR="${FLUTTER_DIR:-$PWD/flutter}"
+
+if [ -d "$FLUTTER_DIR" ]; then
+  echo "Flutter directory exists, updating..."
+  (cd "$FLUTTER_DIR" && git pull --rebase || true)
+else
+  echo "Cloning Flutter..."
+  git clone https://github.com/flutter/flutter.git "$FLUTTER_DIR" --depth 1
+fi
+
+export PATH="$FLUTTER_DIR/bin:$PATH"
+flutter config --enable-web --no-analytics
+flutter doctor
+flutter pub get

--- a/wildmanager/vercel.json
+++ b/wildmanager/vercel.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "installCommand": "if [ -d flutter ]; then (cd flutter && git pull && cd ..); else git clone https://github.com/flutter/flutter.git --depth 1; fi && ./flutter/bin/flutter config --enable-web && ./flutter/bin/flutter doctor",
+  "installCommand": "chmod +x vercel-install.sh && ./vercel-install.sh",
   "buildCommand": "./flutter/bin/flutter pub get && ./flutter/bin/flutter build web --release",
   "outputDirectory": "build/web",
   "routes": [


### PR DESCRIPTION
Add vercel-install.sh to clone or update a local Flutter repo (configurable via FLUTTER_DIR), enable web support, export Flutter to PATH, run flutter doctor and pub get. Update vercel.json to invoke the new script (chmod +x && ./vercel-install.sh) as the installCommand, replacing the previous inline clone/pull command.