### PR TITLE
Add Vercel build script and update vercel.json

### DIFF
--- a/wildmanager/vercel-build.sh
+++ b/wildmanager/vercel-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+FLUTTER_DIR="${FLUTTER_DIR:-$PWD/flutter}"
+export PATH="$FLUTTER_DIR/bin:$PATH"
+
+flutter build web --release

--- a/wildmanager/vercel.json
+++ b/wildmanager/vercel.json
@@ -1,11 +1,8 @@
 {
-  "version": 2,
-  "installCommand": "sh vercel-install.sh",
-  "buildCommand": "sh vercel-build.sh",
+  "installCommand": "chmod +x vercel-install.sh && ./vercel-install.sh",
+  "buildCommand": "chmod +x vercel-build.sh && ./vercel-build.sh",
   "outputDirectory": "build/web",
-  "routes": [
-    { "src": "/(.*\\..*)", "dest": "/$1" },
-    { "src": "/assets/(.*)", "dest": "/assets/$1" },
-    { "src": "/(.*)", "dest": "/index.html" }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Add vercel-build.sh which sets FLUTTER_DIR in PATH and runs `flutter build web`. Update vercel.json to invoke install/build scripts via `chmod +x && ./...` and replace multi-route rules with a single SPA rewrite to `/index.html`; outputDirectory remains `build/web`.