### PR TITLE
Reduce max map zoom and capitalize icon files

### DIFF
--- a/wildmanager/lib/screens/map_screen.dart
+++ b/wildmanager/lib/screens/map_screen.dart
@@ -1355,7 +1355,7 @@ class _MapScreenState extends State<MapScreen> {
     final minZoomRaw = zoomForMaxKm(_maxZoomOutKm, initialCenter.latitude, screenWidth);
     final minZoom = minZoomRaw.clamp(5.0, 12.0);
     final maxZoomRaw = zoomForMaxKm(_minVisibleWidthM / 1000.0, initialCenter.latitude, screenWidth);
-    final maxZoom = maxZoomRaw.clamp(14.0, 22.0);
+    final maxZoom = maxZoomRaw.clamp(14.0, 17.0);
 
     return PopScope(
       canPop: false,

--- a/wildmanager/lib/utils/animal_icon_resolver.dart
+++ b/wildmanager/lib/utils/animal_icon_resolver.dart
@@ -41,18 +41,17 @@ const Map<String, String> _speciesNameAliases = {
   'tauros': 'taurus',
 };
 
-/// Bestandsnaam voor asset (zonder spaties) voor Flutter Web compatibility.
-/// Flutter Web encodeert spaties in asset-URLs dubbel, wat 404 geeft in release builds.
 String iconNameToAssetFileName(String iconName) {
   return iconName.replaceAll(' ', '_');
 }
 
-/// Basis-pad voor diericonen (app-eigen assets onder assets/icons/animals/).
+String _capitalizeFileName(String name) {
+  if (name.isEmpty) return name;
+  return name[0].toUpperCase() + name.substring(1);
+}
+
 const String animalIconsAssetPath = 'assets/icons/animals';
 
-/// Expliciete lijst van alle diericon-bestandsnamen (zonder .png).
-/// Op web release worden dynamische paden soms niet meegenomen; door elke path
-/// hier als literal te zetten, worden alle iconen in de build gebundeld.
 const List<String> animalIconAssetFileNames = [
   'bever',
   'boommarter',
@@ -85,21 +84,18 @@ const List<String> animalIconAssetFileNames = [
   'wolf',
 ];
 
-/// Geeft het asset-pad voor een icoonnaam, of null als onbekend.
-/// Gebruikt de statische lijst zodat web release alle iconen meeneemt.
 String? getAnimalIconAssetPath(String iconName) {
   final fileName = iconNameToAssetFileName(iconName);
   if (animalIconAssetFileNames.contains(fileName)) {
-    return '$animalIconsAssetPath/$fileName.png';
+    return '$animalIconsAssetPath/${_capitalizeFileName(fileName)}.png';
   }
   return null;
 }
 
-/// Asset-paden voor preload (app-eigen assets). Zorgt dat web release alle iconen laadt.
 List<String> getAllAnimalIconAssetKeys() {
   return [
     for (final f in animalIconAssetFileNames)
-      '$animalIconsAssetPath/$f.png',
+      '$animalIconsAssetPath/${_capitalizeFileName(f)}.png',
   ];
 }
 


### PR DESCRIPTION
Reduce the maximum map zoom clamp from 22.0 to 17.0 to limit how far users can zoom in.

Update animal icon asset handling: introduce _capitalizeFileName and use it when composing asset paths and when listing all asset keys, so asset filenames use an uppercase first letter. The static animalIconAssetFileNames list is still used to ensure Flutter Web includes the assets, and iconNameToAssetFileName continues to replace spaces with underscores.